### PR TITLE
tasks: always build before testing

### DIFF
--- a/tasks/grunt-dry.js
+++ b/tasks/grunt-dry.js
@@ -152,12 +152,10 @@ module.exports = function(grunt) {
     ]);
 
     grunt.registerTask('test', [
+        'build',
         'mochaTest',
         'mocha'
     ]);
 
-    grunt.registerTask('default', [
-        'build',
-        'test'
-    ]);
+    grunt.registerTask('default', 'test');
 };


### PR DESCRIPTION
Since the tests require the module symlink and browser build to work
properly, always run the build step before running mocha.
